### PR TITLE
Tressel/add inputs adoption form

### DIFF
--- a/src/Pages/Adopt.jsx
+++ b/src/Pages/Adopt.jsx
@@ -1106,8 +1106,6 @@ export const Adopt = () => {
                         <Checkbox
                           {...field}
                           checked={field["value"] ?? false}
-                          error={Boolean(errors.home_address_agreement?.message)}
-                          helperText={errors.home_address_agreement?.message}
                         />
                       )}
                     />
@@ -1134,8 +1132,6 @@ export const Adopt = () => {
                         <Checkbox
                           {...field}
                           checked={field["value"] ?? false}
-                          error={Boolean(errors.home_visit_agreement?.message)}
-                          helperText={errors.home_visit_agreement?.message}
                         />
                       )}
                     />
@@ -1162,8 +1158,6 @@ export const Adopt = () => {
                         <Checkbox
                           {...field}
                           checked={field["value"] ?? false}
-                          error={Boolean(errors.no_guarantee_agreement?.message)}
-                          helperText={errors.no_guarantee_agreement?.message}
                         />
                       )}
                     />

--- a/src/Pages/Adopt.jsx
+++ b/src/Pages/Adopt.jsx
@@ -893,7 +893,11 @@ export const Adopt = () => {
                   >
                     <TextField
                       id="smokers-explanation"
-                      label="If yes, how do you prevent health-related problems due to second-hand smoke and nicotine exposure for your bird(s)?"
+                      label="If yes, how do you prevent health problems due to second-hand smoke exposure for your bird(s)?"
+                      sx={{
+                        "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                        "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
+                      }}
                       variant="outlined"
                       multiline
                       minRows={4}
@@ -965,7 +969,6 @@ export const Adopt = () => {
                 <TextField
                   id="what-supp-info"
                   label="What sources of information do you use to supplement your knowledge of avian care?"
-                  // allows label to wrap when input not in focus
                   sx={{
                     "& .MuiFormLabel-root": { whiteSpace: "normal" },
                     "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },

--- a/src/Pages/Adopt.jsx
+++ b/src/Pages/Adopt.jsx
@@ -96,13 +96,6 @@ export const Adopt = () => {
   const watchOtherPets = watch("other_pets_in_home", "No");
 
   const onSubmit = (data) => {
-    for (const key of [
-      "home_address_agreement",
-      "home_visit_agreement",
-      "no_guarantee_agreement",
-    ]) {
-      delete data[key];
-    }
     const {
       other_bird_species,
       other_bird_checkup_date,
@@ -116,6 +109,9 @@ export const Adopt = () => {
       weekend_different,
       smokers_explanation,
       what_other_pets,
+      home_address_agreement,
+      home_visit_agreement,
+      no_guarantee_agreement,
       ...submissionData
     } = data;
     if (data.have_other_birds === "Yes") {
@@ -438,6 +434,10 @@ export const Adopt = () => {
                 <TextField
                   id="household-ages"
                   label="What are the ages of everyone in the household?"
+                  sx={{
+                    "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                    "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
+                  }}
                   variant="outlined"
                   {...register("ages_in_household", {
                     required: "Household members' ages are required",
@@ -448,6 +448,10 @@ export const Adopt = () => {
                 <TextField
                   id="children-experience-with-birds"
                   label="Are there children in the household? What is their experience with birds?"
+                  sx={{
+                    "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                    "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
+                  }}
                   variant="outlined"
                   multiline
                   minRows={4}
@@ -522,6 +526,10 @@ export const Adopt = () => {
                       <TextField
                         id="last-bird-checkup-date"
                         label="If you currently have birds, what was the date of their last annual checkup?"
+                        sx={{
+                          "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                          "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
+                        }}
                         variant="outlined"
                         {...register("other_bird_checkup_date", {
                           required: "Last checkup date is required",
@@ -532,6 +540,10 @@ export const Adopt = () => {
                       <TextField
                         id="bird-diet"
                         label="List the current diet that you feed your birds"
+                        sx={{
+                          "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                          "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
+                        }}
                         variant="outlined"
                         multiline
                         minRows={4}
@@ -598,6 +610,10 @@ export const Adopt = () => {
                 <TextField
                   id="other-bird-experience"
                   label="Please list any other bird experience that you may have"
+                  sx={{
+                    "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                    "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
+                  }}
                   variant="outlined"
                   multiline
                   minRows={4}
@@ -849,6 +865,10 @@ export const Adopt = () => {
                 <TextField
                   id="bird-hours-alone"
                   label="How many hours a day will your bird spend alone?"
+                  sx={{
+                    "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                    "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
+                  }}
                   variant="outlined"
                   {...register("bird_hours_alone", { required: "Hours alone is required" })}
                   error={!!errors.bird_hours_alone?.message}

--- a/src/Pages/Adopt.jsx
+++ b/src/Pages/Adopt.jsx
@@ -679,6 +679,41 @@ export const Adopt = () => {
                     </RadioGroup>
                   )}
                 />
+                <FormLabel
+                  id="renter-verification"
+                  sx={{ fontWeight: "bold" }}
+                >
+                  If you are renting, have you verified with landlord that birds are allowed and
+                  that you have a pet deposit?
+                </FormLabel>
+                <Controller
+                  control={control}
+                  name="renter_verification"
+                  render={({ field: { onChange, value, name } }) => (
+                    <RadioGroup
+                      aria-labelledby="renter-verification"
+                      value={value}
+                      name={name}
+                      onChange={onChange}
+                    >
+                      <FormControlLabel
+                        value="Yes"
+                        control={<Radio />}
+                        label="Yes"
+                      />
+                      <FormControlLabel
+                        value="No"
+                        control={<Radio />}
+                        label="No"
+                      />
+                      <FormControlLabel
+                        value="Not yet"
+                        control={<Radio />}
+                        label="Not yet"
+                      />
+                    </RadioGroup>
+                  )}
+                />
                 <Button
                   variant="contained"
                   color="primary"

--- a/src/Pages/Adopt.jsx
+++ b/src/Pages/Adopt.jsx
@@ -1,7 +1,9 @@
 import {
   Button,
+  Checkbox,
   Fade,
   FormControlLabel,
+  FormHelperText,
   FormLabel,
   List,
   ListItem,
@@ -67,11 +69,31 @@ export const Adopt = () => {
       vet_address: "",
       vet_phone: "",
       residence_type: "Single Family House",
+      renter_verification: "Not yet",
+      weekend_different: "No",
+      weekend_routine: "",
+      bird_hours_alone: "",
+      smokers_in_house: "No",
+      smokers_explanation: "",
+      other_pets_in_home: "Yes",
+      what_other_pets: "",
+      what_supp_info: "",
+      lifestyle_changes: "",
+      vacation_care: "",
+      death_plans: "",
+      looking_for_in_bird: "",
+      additional_comments: "",
+      home_address_agreement: false,
+      home_visit_agreement: false,
+      no_guarantee_agreement: false,
     },
   });
   const watchOtherBirds = watch("have_other_birds", "No");
   const watchPreviousBirds = watch("previous_birds", "No");
   const watchAvianVet = watch("have_avian_vet", "No");
+  const watchWeekendDifferent = watch("weekend_different", "No");
+  const watchSmokersInHouse = watch("smokers_in_house", "No");
+  const watchOtherPets = watch("other_pets_in_home", "No");
 
   const onSubmit = (data) => {
     const {
@@ -679,6 +701,8 @@ export const Adopt = () => {
                     </RadioGroup>
                   )}
                 />
+
+                {/* ****************************************************************************************************************** */}
                 <FormLabel
                   id="renter-verification"
                   sx={{ fontWeight: "bold" }}
@@ -714,6 +738,367 @@ export const Adopt = () => {
                     </RadioGroup>
                   )}
                 />
+
+                <TextField
+                  id="daily-routine"
+                  label="Describe your daily routine at home"
+                  variant="outlined"
+                  multiline
+                  minRows={4}
+                  {...register("daily_routine", { required: "Daily routine is required" })}
+                  error={!!errors.daily_routine?.message}
+                  helperText={errors.daily_routine?.message}
+                />
+
+                <FormLabel
+                  id="weekend-different-bool"
+                  sx={{ fontWeight: "bold" }}
+                >
+                  Does your routine differ on weekends?
+                </FormLabel>
+                <Controller
+                  control={control}
+                  name="weekend_different"
+                  render={({ field: { onChange, value, name } }) => (
+                    <RadioGroup
+                      aria-labelledby="weekend-different-bool"
+                      value={value}
+                      name={name}
+                      onChange={(event) => {
+                        clearErrors("weekend_routine");
+                        onChange(event);
+                      }}
+                    >
+                      <FormControlLabel
+                        value="Yes"
+                        control={<Radio />}
+                        label="Yes"
+                      />
+                      <FormControlLabel
+                        value="No"
+                        control={<Radio />}
+                        label="No"
+                      />
+                    </RadioGroup>
+                  )}
+                />
+                {watchWeekendDifferent === "Yes" && (
+                  <Fade
+                    in={true}
+                    timeout={250}
+                  >
+                    <TextField
+                      id="weekend-routine"
+                      label="If yes, please explain"
+                      variant="outlined"
+                      {...register("weekend_routine", {
+                        required: "Weekend routine is required",
+                      })}
+                      error={!!errors.weekend_routine?.message}
+                      helperText={errors.weekend_routine?.message}
+                    />
+                  </Fade>
+                )}
+
+                <TextField
+                  id="bird-hours-alone"
+                  label="How many hours a day will your bird spend alone?"
+                  variant="outlined"
+                  {...register("bird_hours_alone", { required: "Hours alone is required" })}
+                  error={!!errors.bird_hours_alone?.message}
+                  helperText={errors.bird_hours_alone?.message}
+                />
+
+                <FormLabel
+                  id="smokers-in-house-bool"
+                  sx={{ fontWeight: "bold" }}
+                >
+                  Are there smokers in the house?
+                </FormLabel>
+                <Controller
+                  control={control}
+                  name="smokers_in_house"
+                  render={({ field: { onChange, value, name } }) => (
+                    <RadioGroup
+                      aria-labelledby="smokers-in-house-bool"
+                      value={value}
+                      name={name}
+                      onChange={(event) => {
+                        clearErrors("smokers_explanation");
+                        onChange(event);
+                      }}
+                    >
+                      <FormControlLabel
+                        value="Yes"
+                        control={<Radio />}
+                        label="Yes"
+                      />
+                      <FormControlLabel
+                        value="No"
+                        control={<Radio />}
+                        label="No"
+                      />
+                    </RadioGroup>
+                  )}
+                />
+                {watchSmokersInHouse === "Yes" && (
+                  <Fade
+                    in={true}
+                    timeout={250}
+                  >
+                    <TextField
+                      id="smokers-explanation"
+                      label="If yes, how do you prevent health-related problems due to second-hand smoke and nicotine exposure for your bird(s)?"
+                      variant="outlined"
+                      {...register("smokers_explanation", {
+                        required: "Second-hand smoke plan is required",
+                      })}
+                      error={!!errors.smokers_explanation?.message}
+                      helperText={errors.smokers_explanation?.message}
+                    />
+                  </Fade>
+                )}
+
+                <FormLabel
+                  id="other-pets-bool"
+                  sx={{ fontWeight: "bold" }}
+                >
+                  Do you currently have other pets living in your home?
+                </FormLabel>
+                <Controller
+                  control={control}
+                  name="other_pets_in_home"
+                  render={({ field: { onChange, value, name } }) => (
+                    <RadioGroup
+                      aria-labelledby="other-pets-bool"
+                      value={value}
+                      name={name}
+                      onChange={(event) => {
+                        clearErrors("what_other_pets");
+                        onChange(event);
+                      }}
+                    >
+                      <FormControlLabel
+                        value="Yes"
+                        control={<Radio />}
+                        label="Yes"
+                      />
+                      <FormControlLabel
+                        value="No"
+                        control={<Radio />}
+                        label="No"
+                      />
+                    </RadioGroup>
+                  )}
+                />
+                {watchOtherPets === "Yes" && (
+                  <Fade
+                    in={true}
+                    timeout={250}
+                  >
+                    <TextField
+                      id="what-other-pets"
+                      label="If yes, please list species and how many"
+                      variant="outlined"
+                      {...register("what_other_pets", {
+                        required: "Other pets information is required",
+                      })}
+                      error={!!errors.what_other_pets?.message}
+                      helperText={errors.what_other_pets?.message}
+                    />
+                  </Fade>
+                )}
+
+                <TextField
+                  id="what-supp-info"
+                  label="What sources of information do you use to supplement your knowledge of avian care?"
+                  // allows label to wrap when input not in focus
+                  sx={{
+                    "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                    "& .MuiFormLabel-root.Mui-focused": { whiteSpace: "nowrap" },
+                  }}
+                  variant="outlined"
+                  multiline
+                  minRows={4}
+                  {...register("what_supp_info", {
+                    required: "Avian sources of information is required",
+                  })}
+                  error={!!errors.what_supp_info?.message}
+                  helperText={errors.what_supp_info?.message}
+                />
+
+                <TextField
+                  id="lifestyle-changes"
+                  label="Please describe the lifestyle changes you might anticipate over the next 5 years? 10 years? 25 years?"
+                  sx={{
+                    "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                    "& .MuiFormLabel-root.Mui-focused": { whiteSpace: "nowrap" },
+                  }}
+                  variant="outlined"
+                  multiline
+                  minRows={4}
+                  {...register("lifestyle_changes", {
+                    required: "Lifestyle changes description is required",
+                  })}
+                  error={!!errors.lifestyle_changes?.message}
+                  helperText={errors.lifestyle_changes?.message}
+                />
+
+                <TextField
+                  id="vacation-care"
+                  label="When you travel or go on an extended vacation, who will care for your bird?"
+                  sx={{
+                    "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                    "& .MuiFormLabel-root.Mui-focused": { whiteSpace: "nowrap" },
+                  }}
+                  variant="outlined"
+                  multiline
+                  minRows={4}
+                  {...register("vacation_care", {
+                    required: "Vacation care plan is required",
+                  })}
+                  error={!!errors.vacation_care?.message}
+                  helperText={errors.vacation_care?.message}
+                />
+
+                <TextField
+                  id="death-plans"
+                  label="What provisions have you made for your birds and/or other pets in the event of your illness or death?"
+                  sx={{
+                    "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                    "& .MuiFormLabel-root.Mui-focused": { whiteSpace: "nowrap" },
+                  }}
+                  variant="outlined"
+                  multiline
+                  minRows={4}
+                  {...register("death_plans", {
+                    required: "Provisions in case of illness/death is required",
+                  })}
+                  error={!!errors.death_plans?.message}
+                  helperText={errors.death_plans?.message}
+                />
+
+                <TextField
+                  id="looking-for-in-bird"
+                  label="What are the most important characteristics you are looking for in a companion bird?"
+                  sx={{
+                    "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                    "& .MuiFormLabel-root.Mui-focused": { whiteSpace: "nowrap" },
+                  }}
+                  variant="outlined"
+                  multiline
+                  minRows={4}
+                  {...register("looking_for_in_bird", {
+                    required: "Important characteristics is required",
+                  })}
+                  error={!!errors.looking_for_in_bird?.message}
+                  helperText={errors.looking_for_in_bird?.message}
+                />
+
+                <TextField
+                  id="additional-comments"
+                  label="Is there anything else you would like to add/ask that would help in determining your eligibility?"
+                  sx={{
+                    "& .MuiFormLabel-root": { whiteSpace: "normal" },
+                    "& .MuiFormLabel-root.Mui-focused": { whiteSpace: "nowrap" },
+                  }}
+                  variant="outlined"
+                  multiline
+                  minRows={4}
+                  {...register("additional_comments", {
+                    required: false,
+                  })}
+                  error={!!errors.additional_comments?.message}
+                  helperText={errors.additional_comments?.message}
+                />
+
+                {/* ***********ADD GROUP LABEL***************************** */}
+                <FormLabel
+                  id="home-address-agreement"
+                  sx={{ fontWeight: "bold" }}
+                  required
+                >
+                  I understand that if I am approved and adopt a bird that this bird must remain in
+                  my home. If my circumstances change, I understand I must contact a Refuge for
+                  Saving the Wildlife. I will forward any changes to my address(es) and/or phone
+                  number(s) to a Refuge for Saving the Wildlife.
+                </FormLabel>
+                <FormControlLabel
+                  control={
+                    <Controller
+                      name="home_address_agreement"
+                      control={control}
+                      rules={{ required: "Home address agreement is required" }}
+                      render={({ field }) => (
+                        <Checkbox
+                          {...field}
+                          checked={field["value"] ?? false}
+                          error={Boolean(errors.home_address_agreement?.message)}
+                          helperText={errors.home_address_agreement?.message}
+                        />
+                      )}
+                    />
+                  }
+                  label="I Agree"
+                />
+                <FormHelperText error>{errors.home_address_agreement?.message}</FormHelperText>
+
+                <FormLabel
+                  id="home-visit-agreement"
+                  sx={{ fontWeight: "bold" }}
+                  required
+                >
+                  I agree to a home visit prior to approval, and I understand that a Refuge for
+                  Saving the Wildlife representative may make periodic visits to my home.
+                </FormLabel>
+                <FormControlLabel
+                  control={
+                    <Controller
+                      name="home_visit_agreement"
+                      control={control}
+                      rules={{ required: "Home visit agreement is required" }}
+                      render={({ field }) => (
+                        <Checkbox
+                          {...field}
+                          checked={field["value"] ?? false}
+                          error={Boolean(errors.home_visit_agreement?.message)}
+                          helperText={errors.home_visit_agreement?.message}
+                        />
+                      )}
+                    />
+                  }
+                  label="I Agree"
+                />
+                <FormHelperText error>{errors.home_visit_agreement?.message}</FormHelperText>
+
+                <FormLabel
+                  id="no-guarantee-agreement"
+                  sx={{ fontWeight: "bold" }}
+                  required
+                >
+                  I understand that completion of this Adoption Application does not guarantee that
+                  I qualify to adopt a bird from a Refuge for Saving the Wildlife.
+                </FormLabel>
+                <FormControlLabel
+                  control={
+                    <Controller
+                      name="no_guarantee_agreement"
+                      control={control}
+                      rules={{ required: "Adoption not guaranteed understanding is required" }}
+                      render={({ field }) => (
+                        <Checkbox
+                          {...field}
+                          checked={field["value"] ?? false}
+                          error={Boolean(errors.no_guarantee_agreement?.message)}
+                          helperText={errors.no_guarantee_agreement?.message}
+                        />
+                      )}
+                    />
+                  }
+                  label="I Agree"
+                />
+                <FormHelperText error>{errors.no_guarantee_agreement?.message}</FormHelperText>
+
                 <Button
                   variant="contained"
                   color="primary"

--- a/src/Pages/Adopt.jsx
+++ b/src/Pages/Adopt.jsx
@@ -75,7 +75,7 @@ export const Adopt = () => {
       bird_hours_alone: "",
       smokers_in_house: "No",
       smokers_explanation: "",
-      other_pets_in_home: "Yes",
+      other_pets_in_home: "No",
       what_other_pets: "",
       what_supp_info: "",
       lifestyle_changes: "",
@@ -106,6 +106,12 @@ export const Adopt = () => {
       vet_clinic_name,
       vet_address,
       vet_phone,
+      weekend_different,
+      smokers_explanation,
+      what_other_pets,
+      home_address_agreement,
+      home_visit_agreement,
+      no_guarantee_agreement,
       ...submissionData
     } = data;
     if (data.have_other_birds === "Yes") {
@@ -118,6 +124,15 @@ export const Adopt = () => {
       submissionData.avian_vet_info = `Vet: ${vet_name}\nClinic: ${vet_clinic_name}\nAddress: ${vet_address}\nPhone: ${vet_phone}`;
     } else {
       submissionData.avian_vet_info = "No avian vet";
+    }
+    if (weekend_different === "No") {
+      submissionData.weekend_routine = "Same as daily routine";
+    }
+    if (data.smokers_in_house === "Yes") {
+      submissionData.smokers_in_house = `Yes. ${smokers_explanation}`;
+    }
+    if (data.other_pets_in_home === "Yes") {
+      submissionData.other_pets_in_home = `Yes. ${what_other_pets}`;
     }
     // This is where in the future we can send data to the back end
     console.log(submissionData);
@@ -311,6 +326,12 @@ export const Adopt = () => {
           </Typography>
           <Box sx={{ width: "600px", maxWidth: "100%" }}>
             <form onSubmit={handleSubmit(onSubmit)}>
+              <Typography
+                variant="h3"
+                sx={{ mb: 2 }}
+              >
+                General Info
+              </Typography>
               <Stack spacing={2}>
                 <TextField
                   id="name"
@@ -386,6 +407,14 @@ export const Adopt = () => {
                   error={!!errors.hear_about_us?.message}
                   helperText={errors.hear_about_us?.message}
                 />
+              </Stack>
+              <Typography
+                variant="h3"
+                sx={{ mb: 2, mt: 4 }}
+              >
+                Household
+              </Typography>
+              <Stack spacing={2}>
                 <TextField
                   id="how-many-people-in-household"
                   label="How many people are in your household?"
@@ -424,6 +453,14 @@ export const Adopt = () => {
                   error={!!errors.children_in_house?.message}
                   helperText={errors.children_in_house?.message}
                 />
+              </Stack>
+              <Typography
+                variant="h3"
+                sx={{ mb: 2, mt: 4 }}
+              >
+                Bird Experience
+              </Typography>
+              <Stack spacing={2}>
                 <FormLabel
                   id="children-in-future"
                   sx={{ fontWeight: "bold" }}
@@ -647,6 +684,14 @@ export const Adopt = () => {
                     </Stack>
                   </Fade>
                 )}
+              </Stack>
+              <Typography
+                variant="h3"
+                sx={{ mb: 2, mt: 4 }}
+              >
+                Environment
+              </Typography>
+              <Stack spacing={2}>
                 <FormLabel
                   id="residence-type"
                   sx={{ fontWeight: "bold" }}
@@ -791,6 +836,8 @@ export const Adopt = () => {
                       id="weekend-routine"
                       label="If yes, please explain"
                       variant="outlined"
+                      multiline
+                      minRows={4}
                       {...register("weekend_routine", {
                         required: "Weekend routine is required",
                       })}
@@ -850,6 +897,8 @@ export const Adopt = () => {
                       id="smokers-explanation"
                       label="If yes, how do you prevent health-related problems due to second-hand smoke and nicotine exposure for your bird(s)?"
                       variant="outlined"
+                      multiline
+                      minRows={4}
                       {...register("smokers_explanation", {
                         required: "Second-hand smoke plan is required",
                       })}
@@ -908,14 +957,21 @@ export const Adopt = () => {
                     />
                   </Fade>
                 )}
-
+              </Stack>
+              <Typography
+                variant="h3"
+                sx={{ mb: 2, mt: 4 }}
+              >
+                Bird Care
+              </Typography>
+              <Stack spacing={2}>
                 <TextField
                   id="what-supp-info"
                   label="What sources of information do you use to supplement your knowledge of avian care?"
                   // allows label to wrap when input not in focus
                   sx={{
                     "& .MuiFormLabel-root": { whiteSpace: "normal" },
-                    "& .MuiFormLabel-root.Mui-focused": { whiteSpace: "nowrap" },
+                    "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
                   }}
                   variant="outlined"
                   multiline
@@ -932,7 +988,7 @@ export const Adopt = () => {
                   label="Please describe the lifestyle changes you might anticipate over the next 5 years? 10 years? 25 years?"
                   sx={{
                     "& .MuiFormLabel-root": { whiteSpace: "normal" },
-                    "& .MuiFormLabel-root.Mui-focused": { whiteSpace: "nowrap" },
+                    "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
                   }}
                   variant="outlined"
                   multiline
@@ -949,7 +1005,7 @@ export const Adopt = () => {
                   label="When you travel or go on an extended vacation, who will care for your bird?"
                   sx={{
                     "& .MuiFormLabel-root": { whiteSpace: "normal" },
-                    "& .MuiFormLabel-root.Mui-focused": { whiteSpace: "nowrap" },
+                    "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
                   }}
                   variant="outlined"
                   multiline
@@ -966,7 +1022,7 @@ export const Adopt = () => {
                   label="What provisions have you made for your birds and/or other pets in the event of your illness or death?"
                   sx={{
                     "& .MuiFormLabel-root": { whiteSpace: "normal" },
-                    "& .MuiFormLabel-root.Mui-focused": { whiteSpace: "nowrap" },
+                    "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
                   }}
                   variant="outlined"
                   multiline
@@ -977,13 +1033,20 @@ export const Adopt = () => {
                   error={!!errors.death_plans?.message}
                   helperText={errors.death_plans?.message}
                 />
-
+              </Stack>
+              <Typography
+                variant="h3"
+                sx={{ mb: 2, mt: 4 }}
+              >
+                Additional Questions
+              </Typography>
+              <Stack spacing={2}>
                 <TextField
                   id="looking-for-in-bird"
                   label="What are the most important characteristics you are looking for in a companion bird?"
                   sx={{
                     "& .MuiFormLabel-root": { whiteSpace: "normal" },
-                    "& .MuiFormLabel-root.Mui-focused": { whiteSpace: "nowrap" },
+                    "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
                   }}
                   variant="outlined"
                   multiline
@@ -1000,7 +1063,7 @@ export const Adopt = () => {
                   label="Is there anything else you would like to add/ask that would help in determining your eligibility?"
                   sx={{
                     "& .MuiFormLabel-root": { whiteSpace: "normal" },
-                    "& .MuiFormLabel-root.Mui-focused": { whiteSpace: "nowrap" },
+                    "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },
                   }}
                   variant="outlined"
                   multiline
@@ -1011,8 +1074,14 @@ export const Adopt = () => {
                   error={!!errors.additional_comments?.message}
                   helperText={errors.additional_comments?.message}
                 />
-
-                {/* ***********ADD GROUP LABEL***************************** */}
+              </Stack>
+              <Typography
+                variant="h3"
+                sx={{ mb: 2, mt: 4 }}
+              >
+                Agreements
+              </Typography>
+              <Stack spacing={2}>
                 <FormLabel
                   id="home-address-agreement"
                   sx={{ fontWeight: "bold" }}

--- a/src/Pages/Adopt.jsx
+++ b/src/Pages/Adopt.jsx
@@ -96,6 +96,13 @@ export const Adopt = () => {
   const watchOtherPets = watch("other_pets_in_home", "No");
 
   const onSubmit = (data) => {
+    for (const key of [
+      "home_address_agreement",
+      "home_visit_agreement",
+      "no_guarantee_agreement",
+    ]) {
+      delete data[key];
+    }
     const {
       other_bird_species,
       other_bird_checkup_date,
@@ -109,9 +116,6 @@ export const Adopt = () => {
       weekend_different,
       smokers_explanation,
       what_other_pets,
-      home_address_agreement,
-      home_visit_agreement,
-      no_guarantee_agreement,
       ...submissionData
     } = data;
     if (data.have_other_birds === "Yes") {
@@ -129,10 +133,10 @@ export const Adopt = () => {
       submissionData.weekend_routine = "Same as daily routine";
     }
     if (data.smokers_in_house === "Yes") {
-      submissionData.smokers_in_house = `Yes. ${smokers_explanation}`;
+      submissionData.smokers_in_house = `Yes\nExplanation: ${smokers_explanation}`;
     }
     if (data.other_pets_in_home === "Yes") {
-      submissionData.other_pets_in_home = `Yes. ${what_other_pets}`;
+      submissionData.other_pets_in_home = `Yes.\nOther Pets: ${what_other_pets}`;
     }
     // This is where in the future we can send data to the back end
     console.log(submissionData);

--- a/src/Pages/Adopt.jsx
+++ b/src/Pages/Adopt.jsx
@@ -750,8 +750,6 @@ export const Adopt = () => {
                     </RadioGroup>
                   )}
                 />
-
-                {/* ****************************************************************************************************************** */}
                 <FormLabel
                   id="renter-verification"
                   sx={{ fontWeight: "bold" }}
@@ -787,7 +785,6 @@ export const Adopt = () => {
                     </RadioGroup>
                   )}
                 />
-
                 <TextField
                   id="daily-routine"
                   label="Describe your daily routine at home"
@@ -798,7 +795,6 @@ export const Adopt = () => {
                   error={!!errors.daily_routine?.message}
                   helperText={errors.daily_routine?.message}
                 />
-
                 <FormLabel
                   id="weekend-different-bool"
                   sx={{ fontWeight: "bold" }}
@@ -850,7 +846,6 @@ export const Adopt = () => {
                     />
                   </Fade>
                 )}
-
                 <TextField
                   id="bird-hours-alone"
                   label="How many hours a day will your bird spend alone?"
@@ -859,7 +854,6 @@ export const Adopt = () => {
                   error={!!errors.bird_hours_alone?.message}
                   helperText={errors.bird_hours_alone?.message}
                 />
-
                 <FormLabel
                   id="smokers-in-house-bool"
                   sx={{ fontWeight: "bold" }}
@@ -911,7 +905,6 @@ export const Adopt = () => {
                     />
                   </Fade>
                 )}
-
                 <FormLabel
                   id="other-pets-bool"
                   sx={{ fontWeight: "bold" }}
@@ -986,7 +979,6 @@ export const Adopt = () => {
                   error={!!errors.what_supp_info?.message}
                   helperText={errors.what_supp_info?.message}
                 />
-
                 <TextField
                   id="lifestyle-changes"
                   label="Please describe the lifestyle changes you might anticipate over the next 5 years? 10 years? 25 years?"
@@ -1003,7 +995,6 @@ export const Adopt = () => {
                   error={!!errors.lifestyle_changes?.message}
                   helperText={errors.lifestyle_changes?.message}
                 />
-
                 <TextField
                   id="vacation-care"
                   label="When you travel or go on an extended vacation, who will care for your bird?"
@@ -1020,7 +1011,6 @@ export const Adopt = () => {
                   error={!!errors.vacation_care?.message}
                   helperText={errors.vacation_care?.message}
                 />
-
                 <TextField
                   id="death-plans"
                   label="What provisions have you made for your birds and/or other pets in the event of your illness or death?"
@@ -1061,7 +1051,6 @@ export const Adopt = () => {
                   error={!!errors.looking_for_in_bird?.message}
                   helperText={errors.looking_for_in_bird?.message}
                 />
-
                 <TextField
                   id="additional-comments"
                   label="Is there anything else you would like to add/ask that would help in determining your eligibility?"
@@ -1113,7 +1102,6 @@ export const Adopt = () => {
                   label="I Agree"
                 />
                 <FormHelperText error>{errors.home_address_agreement?.message}</FormHelperText>
-
                 <FormLabel
                   id="home-visit-agreement"
                   sx={{ fontWeight: "bold" }}
@@ -1139,7 +1127,6 @@ export const Adopt = () => {
                   label="I Agree"
                 />
                 <FormHelperText error>{errors.home_visit_agreement?.message}</FormHelperText>
-
                 <FormLabel
                   id="no-guarantee-agreement"
                   sx={{ fontWeight: "bold" }}
@@ -1165,7 +1152,6 @@ export const Adopt = () => {
                   label="I Agree"
                 />
                 <FormHelperText error>{errors.no_guarantee_agreement?.message}</FormHelperText>
-
                 <Button
                   variant="contained"
                   color="primary"

--- a/src/Pages/Adopt.jsx
+++ b/src/Pages/Adopt.jsx
@@ -754,8 +754,8 @@ export const Adopt = () => {
                   id="renter-verification"
                   sx={{ fontWeight: "bold" }}
                 >
-                  If you are renting, have you verified with landlord that birds are allowed and
-                  that you have a pet deposit?
+                  If you are renting, have you verified with your landlord that birds are allowed
+                  and that you have a pet deposit?
                 </FormLabel>
                 <Controller
                   control={control}


### PR DESCRIPTION
### What I did:
1. **I added numerous new inputs to the form**. Everything from "If you are renting, have you verified with landlord that birds are allowed and that you have a pet deposit?
2. **I fixed an issue with long input labels getting cut off**. Long input labels are naturally cut off with an elipsis in Material UI if the label is too long to fit in one line. I had to add some custom CSS to the SX prop in some TextInput elements to make the input label wrap. I, then, needed some additional CSS to force the label text to unwrap for the minimized version of the label. Example:
![input label wrap solution](https://github.com/allie-rae/rescue-the-birds/assets/109903708/726ee3bd-5677-400e-800c-56e20d56230e)
3. **I added additional headers to mark sections** of the form. It is a really long form, and I felt it was maybe a good idea to find a way to break up the sections a bit. I broke it up into sections similarly to how the original website broke it up into sections (although the original website actually had separate pages).
4. **I adjusted the submission data** in a format that should be good for the google sheet. There are some extra fields that Jon's backend doesn't have yet. Numbers in the screenshot correspond to the order of the text inputs in the form.

![submission fields](https://github.com/allie-rae/rescue-the-birds/assets/109903708/2585602a-25c6-40bb-bac2-c29784d5be5a)

### Things I'm not sure about:
1. Do you like the headers to break up the form?
2. Do you like how I handled the long input labels? Alternatively, we could also just shorten them or put them above the input.
3. Can you double-check that I included the right inputs that the owners want? I did my best to include the right inputs from our conversation, but it's possible that I did something wrong.