### PR TITLE
:lipstick: Make boarding form flow clearer

### DIFF
--- a/src/Pages/Board/ParrotBoardingSubForm.jsx
+++ b/src/Pages/Board/ParrotBoardingSubForm.jsx
@@ -14,6 +14,7 @@ import { Box } from "@mui/system";
 import { Controller, useForm } from "react-hook-form";
 import { useEffect } from "react";
 import CloseIcon from "@mui/icons-material/Close";
+import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 
 export const ParrotBoardingForm = ({
   parentRegister,
@@ -348,8 +349,9 @@ export const ParrotBoardingForm = ({
             color="primary"
             sx={{ width: "250px", mt: 2 }}
             onClick={() => addBird()}
+            startIcon={<AddCircleOutlineIcon />}
           >
-            Add Bird
+            Add this bird
           </Button>
           {hasBirdBeenAdded && (
             <Button


### PR DESCRIPTION
### Description

Previously, the user flow for the boarding form was confusing because it wasn't obvious the user needed to click the "Add Bird" button to complete the form. This PR updates the "Add Bird" button to say "Add this bird". It now has a plus icon, as well. I'm hoping this will improve clarity for the user so they know they need to hit that button before continuing on with the form. 

Here's what the new button looks like: 
<img width="644" alt="Screenshot 2024-01-09 at 5 16 27 PM" src="https://github.com/allie-rae/rescue-the-birds/assets/48700332/b9145422-15a9-4859-8d17-c1c215fa54fb">
