### PR TITLE
:art: Boarding form updates

### DIFF
--- a/src/Pages/Board/AddedBirdsList.jsx
+++ b/src/Pages/Board/AddedBirdsList.jsx
@@ -1,0 +1,28 @@
+import { FormLabel, List, ListItem, ListItemIcon, ListItemText } from "@mui/material";
+import TaskAltIcon from "@mui/icons-material/TaskAlt";
+
+export const AddedBirdsList = ({ birdNames }) => {
+  if (!birdNames.length) return null;
+  return (
+    <>
+      <FormLabel
+        id="emergency-agreement"
+        sx={{ fontWeight: "bold" }}
+      >
+        {birdNames.length === 1 ? "Bird" : "Birds"} added:
+      </FormLabel>
+      <List>
+        {birdNames.map((name) => {
+          return (
+            <ListItem key={name}>
+              <ListItemIcon>
+                <TaskAltIcon color="success" />
+              </ListItemIcon>
+              <ListItemText>{name}</ListItemText>
+            </ListItem>
+          );
+        })}
+      </List>
+    </>
+  );
+};

--- a/src/Pages/Board/Board.jsx
+++ b/src/Pages/Board/Board.jsx
@@ -200,67 +200,116 @@ export const Board = () => {
                 >
                   Personal Information
                 </FormLabel>
-                <TextField
-                  id="name"
-                  label="Name"
-                  variant="outlined"
-                  type="text"
-                  {...register("person_name", { required: "Name is required" })}
-                  error={Boolean(errors.person_name?.message)}
-                  helperText={errors.person_name?.message}
+                <Controller
+                  control={control}
+                  name="person_name"
+                  rules={{ required: "Name is required" }}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      id="name"
+                      label="Name"
+                      variant="outlined"
+                      type="text"
+                      error={Boolean(errors.person_name?.message)}
+                      helperText={errors.person_name?.message}
+                    />
+                  )}
                 />
-                <TextField
-                  id="email"
-                  label="Email"
-                  variant="outlined"
-                  type="email"
-                  {...register("person_email", { required: "Email is required" })}
-                  error={Boolean(errors.person_email?.message)}
-                  helperText={errors.person_email?.message}
+                <Controller
+                  control={control}
+                  name="person_email"
+                  rules={{ required: "Email is required" }}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      id="email"
+                      label="Email"
+                      variant="outlined"
+                      type="email"
+                      error={Boolean(errors.person_email?.message)}
+                      helperText={errors.person_email?.message}
+                    />
+                  )}
                 />
-                <TextField
-                  id="phone-number"
-                  label="Phone Number"
-                  variant="outlined"
-                  type="tel"
-                  {...register("person_phone", { required: "Phone number is required" })}
-                  error={Boolean(errors.person_phone?.message)}
-                  helperText={errors.person_phone?.message}
+                <Controller
+                  control={control}
+                  name="person_phone"
+                  rules={{ required: "Phone number is required" }}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      id="phone-number"
+                      label="Phone Number"
+                      variant="outlined"
+                      type="tel"
+                      error={Boolean(errors.person_phone?.message)}
+                      helperText={errors.person_phone?.message}
+                    />
+                  )}
                 />
-                <TextField
-                  id="street-address"
-                  label="Street Address"
-                  variant="outlined"
-                  {...register("person_address", { required: "Street address is required" })}
-                  error={Boolean(errors.person_address?.message)}
-                  helperText={errors.person_address?.message}
+                <Controller
+                  control={control}
+                  name="person_address"
+                  rules={{ required: "Street address is required" }}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      id="street-address"
+                      label="Street Address"
+                      variant="outlined"
+                      error={Boolean(errors.person_address?.message)}
+                      helperText={errors.person_address?.message}
+                    />
+                  )}
                 />
-                <TextField
-                  id="city"
-                  label="City"
-                  variant="outlined"
-                  type="text"
-                  {...register("person_city", { required: "City is required" })}
-                  error={Boolean(errors.person_city?.message)}
-                  helperText={errors.person_city?.message}
+                <Controller
+                  control={control}
+                  name="person_city"
+                  rules={{ required: "City is required" }}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      id="city"
+                      label="City"
+                      variant="outlined"
+                      type="text"
+                      error={Boolean(errors.person_city?.message)}
+                      helperText={errors.person_city?.message}
+                    />
+                  )}
                 />
-                <TextField
-                  id="state"
-                  label="State"
-                  variant="outlined"
-                  type="text"
-                  {...register("person_state", { required: "State is required" })}
-                  error={Boolean(errors.person_state?.message)}
-                  helperText={errors.person_state?.message}
+                <Controller
+                  control={control}
+                  name="person_state"
+                  rules={{ required: "State is required" }}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      id="state"
+                      label="State"
+                      variant="outlined"
+                      type="text"
+                      error={Boolean(errors.person_state?.message)}
+                      helperText={errors.person_state?.message}
+                    />
+                  )}
                 />
-                <TextField
-                  id="zip-code"
-                  label="Zip Code"
-                  variant="outlined"
-                  type="text"
-                  {...register("person_zipcode", { required: "Zip code is required" })}
-                  error={Boolean(errors.person_zipcode?.message)}
-                  helperText={errors.person_zipcode?.message}
+                <Controller
+                  control={control}
+                  name="person_zipcode"
+                  rules={{ required: "Zip code is required" }}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      id="zip-code"
+                      label="Zip Code"
+                      variant="outlined"
+                      type="text"
+                      error={Boolean(errors.person_zipcode?.message)}
+                      helperText={errors.person_zipcode?.message}
+                    />
+                  )}
                 />
                 <FormLabel
                   id="boarding-schedule"
@@ -268,27 +317,39 @@ export const Board = () => {
                 >
                   Boarding Schedule
                 </FormLabel>
-                <TextField
-                  id="boarding-start-date"
-                  label="Boarding Start Date"
-                  variant="outlined"
-                  type="date"
-                  {...register("boarding_start_date", {
-                    required: "Boarding start date is required",
-                  })}
-                  error={Boolean(errors.boarding_start_date?.message)}
-                  helperText={errors.boarding_start_date?.message}
-                  InputLabelProps={{ shrink: true }}
+                <Controller
+                  control={control}
+                  name="boarding_start_date"
+                  rules={{ required: "Boarding start date is required" }}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      id="boarding-start-date"
+                      label="Boarding Start Date"
+                      variant="outlined"
+                      type="date"
+                      error={Boolean(errors.boarding_start_date?.message)}
+                      helperText={errors.boarding_start_date?.message}
+                      InputLabelProps={{ shrink: true }}
+                    />
+                  )}
                 />
-                <TextField
-                  id="boarding-end-date"
-                  label="Boarding End Date"
-                  variant="outlined"
-                  type="date"
-                  {...register("boarding_end_date", { required: "Boarding end date is required" })}
-                  error={Boolean(errors.boarding_end_date?.message)}
-                  helperText={errors.boarding_end_date?.message}
-                  InputLabelProps={{ shrink: true }}
+                <Controller
+                  control={control}
+                  name="boarding_end_date"
+                  rules={{ required: "Boarding end date is required" }}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      id="boarding-end-date"
+                      label="Boarding End Date"
+                      variant="outlined"
+                      type="date"
+                      error={Boolean(errors.boarding_end_date?.message)}
+                      helperText={errors.boarding_end_date?.message}
+                      InputLabelProps={{ shrink: true }}
+                    />
+                  )}
                 />
                 <AddedBirdsList birdNames={addedBirdNames} />
                 {!isParrotFormOpen && (

--- a/src/Pages/Board/Board.jsx
+++ b/src/Pages/Board/Board.jsx
@@ -53,6 +53,7 @@ export const Board = () => {
       legal_agreement: false,
     },
   });
+
   const [addedBirdNames, setAddedBirdNames] = useState([]);
   const [isParrotFormOpen, setIsParrotFormOpen] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
@@ -76,11 +77,22 @@ export const Board = () => {
       emergency_agreement,
       legal_agreement,
       vet_record_agreement,
+      boarding_start_date,
+      boarding_end_date,
       ...rest
     } = data;
+
+    const boardingStartDateArr = boarding_start_date.split("-");
+    const boardingEndDateArr = boarding_end_date.split("-");
+
+    const reformattedBoardingStartDate = `${boardingStartDateArr[1]}/${boardingStartDateArr[2]}/${boardingStartDateArr[0]}`;
+    const reformattedBoardingEndDate = `${boardingEndDateArr[1]}/${boardingEndDateArr[2]}/${boardingEndDateArr[0]}`;
+
     axios
       .post("https://rescuethebirds-jfcaxndkka-uc.a.run.app/forms/boarding", {
         ...rest,
+        boarding_start_date: reformattedBoardingStartDate,
+        boarding_end_date: reformattedBoardingEndDate,
       })
       .then(() => {
         setIsSuccess(true);
@@ -192,6 +204,7 @@ export const Board = () => {
                   id="name"
                   label="Name"
                   variant="outlined"
+                  type="text"
                   {...register("person_name", { required: "Name is required" })}
                   error={Boolean(errors.person_name?.message)}
                   helperText={errors.person_name?.message}
@@ -200,6 +213,7 @@ export const Board = () => {
                   id="email"
                   label="Email"
                   variant="outlined"
+                  type="email"
                   {...register("person_email", { required: "Email is required" })}
                   error={Boolean(errors.person_email?.message)}
                   helperText={errors.person_email?.message}
@@ -208,6 +222,7 @@ export const Board = () => {
                   id="phone-number"
                   label="Phone Number"
                   variant="outlined"
+                  type="tel"
                   {...register("person_phone", { required: "Phone number is required" })}
                   error={Boolean(errors.person_phone?.message)}
                   helperText={errors.person_phone?.message}
@@ -224,6 +239,7 @@ export const Board = () => {
                   id="city"
                   label="City"
                   variant="outlined"
+                  type="text"
                   {...register("person_city", { required: "City is required" })}
                   error={Boolean(errors.person_city?.message)}
                   helperText={errors.person_city?.message}
@@ -232,6 +248,7 @@ export const Board = () => {
                   id="state"
                   label="State"
                   variant="outlined"
+                  type="text"
                   {...register("person_state", { required: "State is required" })}
                   error={Boolean(errors.person_state?.message)}
                   helperText={errors.person_state?.message}
@@ -240,6 +257,7 @@ export const Board = () => {
                   id="zip-code"
                   label="Zip Code"
                   variant="outlined"
+                  type="text"
                   {...register("person_zipcode", { required: "Zip code is required" })}
                   error={Boolean(errors.person_zipcode?.message)}
                   helperText={errors.person_zipcode?.message}
@@ -252,21 +270,25 @@ export const Board = () => {
                 </FormLabel>
                 <TextField
                   id="boarding-start-date"
-                  label="Boarding Start Date (MM/DD/YYYY)"
+                  label="Boarding Start Date"
                   variant="outlined"
+                  type="date"
                   {...register("boarding_start_date", {
                     required: "Boarding start date is required",
                   })}
                   error={Boolean(errors.boarding_start_date?.message)}
                   helperText={errors.boarding_start_date?.message}
+                  InputLabelProps={{ shrink: true }}
                 />
                 <TextField
                   id="boarding-end-date"
-                  label="Boarding End Date (MM/DD/YYYY)"
+                  label="Boarding End Date"
                   variant="outlined"
+                  type="date"
                   {...register("boarding_end_date", { required: "Boarding end date is required" })}
                   error={Boolean(errors.boarding_end_date?.message)}
                   helperText={errors.boarding_end_date?.message}
+                  InputLabelProps={{ shrink: true }}
                 />
                 <AddedBirdsList birdNames={addedBirdNames} />
                 {!isParrotFormOpen && (
@@ -308,8 +330,6 @@ export const Board = () => {
                         <Checkbox
                           {...field}
                           checked={field["value"] ?? false}
-                          error={Boolean(errors.vet_record_agreement?.message)}
-                          helperText={errors.vet_record_agreement?.message}
                         />
                       )}
                     />
@@ -336,8 +356,6 @@ export const Board = () => {
                         <Checkbox
                           {...field}
                           checked={field["value"] ?? false}
-                          error={Boolean(errors.dropoff_agreement?.message)}
-                          helperText={errors.dropoff_agreement?.message}
                         />
                       )}
                     />
@@ -364,8 +382,6 @@ export const Board = () => {
                         <Checkbox
                           {...field}
                           checked={field["value"] ?? false}
-                          error={Boolean(errors.emergency_agreement?.message)}
-                          helperText={errors.emergency_agreement?.message}
                         />
                       )}
                     />
@@ -405,8 +421,6 @@ export const Board = () => {
                         <Checkbox
                           {...field}
                           checked={field["value"] ?? false}
-                          error={Boolean(errors.legal_agreement?.message)}
-                          helperText={errors.legal_agreement?.message}
                         />
                       )}
                     />

--- a/src/Pages/Board/Board.jsx
+++ b/src/Pages/Board/Board.jsx
@@ -7,10 +7,6 @@ import {
   FormHelperText,
   FormLabel,
   LinearProgress,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
   Stack,
   TextField,
   Typography,
@@ -22,9 +18,9 @@ import AddCircleIcon from "@mui/icons-material/AddCircle";
 import { PricingTable } from "../../PricingTable";
 import { Controller, useForm } from "react-hook-form";
 import { useEffect, useState } from "react";
-import TaskAltIcon from "@mui/icons-material/TaskAlt";
 import { ParrotBoardingForm } from "./ParrotBoardingSubForm";
 import { TextInput } from "../../TextInput";
+import { AddedBirdsList } from "./AddedBirdsList";
 
 const textFields = [
   {
@@ -458,31 +454,5 @@ export const Board = () => {
         </Box>
       </Box>
     </Fade>
-  );
-};
-
-const AddedBirdsList = ({ birdNames }) => {
-  if (!birdNames.length) return null;
-  return (
-    <>
-      <FormLabel
-        id="emergency-agreement"
-        sx={{ fontWeight: "bold" }}
-      >
-        {birdNames.length === 1 ? "Bird" : "Birds"} added:
-      </FormLabel>
-      <List>
-        {birdNames.map((name) => {
-          return (
-            <ListItem key={name}>
-              <ListItemIcon>
-                <TaskAltIcon color="success" />
-              </ListItemIcon>
-              <ListItemText>{name}</ListItemText>
-            </ListItem>
-          );
-        })}
-      </List>
-    </>
   );
 };

--- a/src/Pages/Board/Board.jsx
+++ b/src/Pages/Board/Board.jsx
@@ -24,6 +24,7 @@ import { Controller, useForm } from "react-hook-form";
 import { useEffect, useState } from "react";
 import TaskAltIcon from "@mui/icons-material/TaskAlt";
 import { ParrotBoardingForm } from "./ParrotBoardingSubForm";
+import { TextInput } from "../../TextInput";
 
 const textFields = [
   {
@@ -247,22 +248,14 @@ export const Board = () => {
                 </FormLabel>
                 {textFields.map((textField) => {
                   return (
-                    <Controller
+                    <TextInput
                       key={textField.name}
-                      control={control}
                       name={textField.name}
+                      control={control}
                       rules={textField.rules}
-                      render={({ field }) => (
-                        <TextField
-                          {...field}
-                          id={textField.name}
-                          label={textField.label}
-                          variant="outlined"
-                          type={textField.type}
-                          error={Boolean(errors[textField.name]?.message)}
-                          helperText={errors[textField.name]?.message}
-                        />
-                      )}
+                      label={textField.label}
+                      type={textField.type}
+                      errors={errors}
                     />
                   );
                 })}

--- a/src/Pages/Board/Board.jsx
+++ b/src/Pages/Board/Board.jsx
@@ -25,6 +25,51 @@ import { useEffect, useState } from "react";
 import TaskAltIcon from "@mui/icons-material/TaskAlt";
 import { ParrotBoardingForm } from "./ParrotBoardingSubForm";
 
+const textFields = [
+  {
+    name: "person_name",
+    label: "Name",
+    rules: { required: "Name is required" },
+    type: "text",
+  },
+  {
+    name: "person_email",
+    label: "Email",
+    rules: { required: "Email is required" },
+    type: "email",
+  },
+  {
+    name: "person_phone",
+    label: "Phone Number",
+    rules: { required: "Phone number is required" },
+    type: "tel",
+  },
+  {
+    name: "person_address",
+    label: "Street Address",
+    rules: { required: "Street address is required" },
+    type: "text",
+  },
+  {
+    name: "person_city",
+    label: "City",
+    rules: { required: "City is required" },
+    type: "text",
+  },
+  {
+    name: "person_state",
+    label: "State",
+    rules: { required: "State is required" },
+    type: "text",
+  },
+  {
+    name: "person_zipcode",
+    label: "Zip Code",
+    rules: { required: "Zip code is required" },
+    type: "text",
+  },
+];
+
 export const Board = () => {
   const {
     register,
@@ -200,117 +245,27 @@ export const Board = () => {
                 >
                   Personal Information
                 </FormLabel>
-                <Controller
-                  control={control}
-                  name="person_name"
-                  rules={{ required: "Name is required" }}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      id="name"
-                      label="Name"
-                      variant="outlined"
-                      type="text"
-                      error={Boolean(errors.person_name?.message)}
-                      helperText={errors.person_name?.message}
+                {textFields.map((textField) => {
+                  return (
+                    <Controller
+                      key={textField.name}
+                      control={control}
+                      name={textField.name}
+                      rules={textField.rules}
+                      render={({ field }) => (
+                        <TextField
+                          {...field}
+                          id={textField.name}
+                          label={textField.label}
+                          variant="outlined"
+                          type={textField.type}
+                          error={Boolean(errors[textField.name]?.message)}
+                          helperText={errors[textField.name]?.message}
+                        />
+                      )}
                     />
-                  )}
-                />
-                <Controller
-                  control={control}
-                  name="person_email"
-                  rules={{ required: "Email is required" }}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      id="email"
-                      label="Email"
-                      variant="outlined"
-                      type="email"
-                      error={Boolean(errors.person_email?.message)}
-                      helperText={errors.person_email?.message}
-                    />
-                  )}
-                />
-                <Controller
-                  control={control}
-                  name="person_phone"
-                  rules={{ required: "Phone number is required" }}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      id="phone-number"
-                      label="Phone Number"
-                      variant="outlined"
-                      type="tel"
-                      error={Boolean(errors.person_phone?.message)}
-                      helperText={errors.person_phone?.message}
-                    />
-                  )}
-                />
-                <Controller
-                  control={control}
-                  name="person_address"
-                  rules={{ required: "Street address is required" }}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      id="street-address"
-                      label="Street Address"
-                      variant="outlined"
-                      error={Boolean(errors.person_address?.message)}
-                      helperText={errors.person_address?.message}
-                    />
-                  )}
-                />
-                <Controller
-                  control={control}
-                  name="person_city"
-                  rules={{ required: "City is required" }}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      id="city"
-                      label="City"
-                      variant="outlined"
-                      type="text"
-                      error={Boolean(errors.person_city?.message)}
-                      helperText={errors.person_city?.message}
-                    />
-                  )}
-                />
-                <Controller
-                  control={control}
-                  name="person_state"
-                  rules={{ required: "State is required" }}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      id="state"
-                      label="State"
-                      variant="outlined"
-                      type="text"
-                      error={Boolean(errors.person_state?.message)}
-                      helperText={errors.person_state?.message}
-                    />
-                  )}
-                />
-                <Controller
-                  control={control}
-                  name="person_zipcode"
-                  rules={{ required: "Zip code is required" }}
-                  render={({ field }) => (
-                    <TextField
-                      {...field}
-                      id="zip-code"
-                      label="Zip Code"
-                      variant="outlined"
-                      type="text"
-                      error={Boolean(errors.person_zipcode?.message)}
-                      helperText={errors.person_zipcode?.message}
-                    />
-                  )}
-                />
+                  );
+                })}
                 <FormLabel
                   id="boarding-schedule"
                   sx={{ fontWeight: "bold" }}

--- a/src/TextInput/TextInput.jsx
+++ b/src/TextInput/TextInput.jsx
@@ -1,0 +1,24 @@
+import { TextField } from "@mui/material";
+import { Controller } from "react-hook-form";
+
+export const TextInput = ({ name, control, rules, label, type, errors }) => {
+  return (
+    <Controller
+      key={name}
+      control={control}
+      name={name}
+      rules={rules}
+      render={({ field }) => (
+        <TextField
+          {...field}
+          id={name}
+          label={label}
+          variant="outlined"
+          type={type}
+          error={Boolean(errors[name]?.message)}
+          helperText={errors[name]?.message}
+        />
+      )}
+    />
+  );
+};

--- a/src/TextInput/index.js
+++ b/src/TextInput/index.js
@@ -1,0 +1,1 @@
+export { TextInput } from "./TextInput";


### PR DESCRIPTION
### Description 

This updates the boarding form in a few different ways, including:
- Adding the `date` type to the boarding start and end inputs (making these inputs datepickers)
- Adding formatting so that the dates show up as mm/dd/yyyy
- Adding `InputLabelProps` so that the labels of the datepickers stay small and don't overlap with the placeholder 
- Adding `text`, `email`, and `tel` types
- Deleting the `helperText` and `error` props from checkboxes to get rid of the console error (thanks @dtressel for the tip!)
- Adding the `Controller` component to the text fields for proper state management (thanks @JohnathonBowers for the tip!)
- Shortening the form by mapping over a list of input information
- Moved `AddedBirdsList` to keep file size small