### PR TITLE
:lipstick: Shorten household ages input label

### DIFF
--- a/src/Pages/Adopt.jsx
+++ b/src/Pages/Adopt.jsx
@@ -433,7 +433,7 @@ export const Adopt = () => {
                 />
                 <TextField
                   id="household-ages"
-                  label="What are the ages of everyone in the household?"
+                  label="List the ages of everyone in the household"
                   sx={{
                     "& .MuiFormLabel-root": { whiteSpace: "normal" },
                     "& .MuiFormLabel-root.MuiInputLabel-shrink": { whiteSpace: "nowrap" },


### PR DESCRIPTION
### Description

This shortens the label of one input on the adoption form (the household ages input) so that it looks better on mobile. 

### Screenshot

Here is what the new label looks like on mobile:
<img width="269" alt="Screenshot 2024-01-12 at 2 16 53 AM" src="https://github.com/allie-rae/rescue-the-birds/assets/48700332/3e85c923-153d-4ec3-a3de-db41a99b643f">

The old label on mobile:
<img width="269" alt="Screenshot 2024-01-12 at 2 21 06 AM" src="https://github.com/allie-rae/rescue-the-birds/assets/48700332/e12febdf-1790-476e-ba80-35f81395d57b">
